### PR TITLE
[Choice] Checkbox style fix

### DIFF
--- a/src/components/Choice/_Choice.scss
+++ b/src/components/Choice/_Choice.scss
@@ -13,8 +13,9 @@ $choice-switch-width: 24px;
   }
 
   &--disabled {
+
     .ui__choice__label,
-    .ui__choice__input > input {
+    .ui__choice__input>input {
       cursor: default;
     }
   }
@@ -120,10 +121,12 @@ $choice-switch-width: 24px;
       left: -2px;
     }
 
-    > input {
+    >input {
       cursor: pointer;
       opacity: 0;
       position: absolute;
+      top: 0;
+      left: 0;
       height: $choice-check-size;
       width: $choice-check-size;
     }
@@ -132,7 +135,7 @@ $choice-switch-width: 24px;
       height: $choice-check-size; // Keep as full-height to center switch.
       width: $choice-switch-width;
 
-      > input {
+      >input {
         height: $choice-switch-size;
         width: $choice-switch-width;
       }


### PR DESCRIPTION
<!--
  BEFORE OPENING THIS PR:

  1. Set title of PR:
      [ComponentName] Changes to the component
      [core] Changes to script, core files
      [docs] Changes to documentation

     If those don't cover your PR, choose any tag that makes sense.

  2. Update all of the information below.

  3. If this is a WIP, add the 🚧 emoji at the beginning, and open a DRAFT PR.
     See: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

### Description

This PR is to fix the issue where the thumbnail checkbox isn't clickable sometimes.
It turns out to be a pure CSS issue where the position of the input element is off. To let this absolute position element sit at the right place we simply add top:0, left:0 to the styles.

Resolves WVR-93
https://pdftron.atlassian.net/browse/WVR-93

![checkbox](https://user-images.githubusercontent.com/12532515/216572253-614409cd-3ddf-4f9b-9abb-7ea0c0b2d643.png)

