### PR TITLE
[Utils] - Updated webviewerUtils.ts deprecated thumbnail call

### DIFF
--- a/src/utils/webviewerUtils.ts
+++ b/src/utils/webviewerUtils.ts
@@ -100,7 +100,7 @@ export async function getThumbnail(
         if (!result) return reject(result);
         resolve(result);
       };
-      fetchedDocument.loadThumbnailAsync(pageNumber, callback);
+      fetchedDocument.loadThumbnail(pageNumber, callback);
     });
 
     const url = canvas.toDataURL();


### PR DESCRIPTION
### Description

- Updated the `WebViewerUtils.ts` to replace the deprecated (in 8.3) `loadThumbnailAsync` call with the correct `loadThumbnail` call. Otherwise using the toolkit against v10.0.0 will result in no thumbnails being generated.

### Related issues

- None

### Checklist

- None
